### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
    ```elixir
    def deps do
-     [{:ueberauth_spotify, git: "https://github.com/sondr3/ueberauth-spotify", tag: "v0.1.0"}]
+     [{:ueberauth_spotify, git: "https://github.com/sondr3/ueberauth_spotify", tag: "v0.1.0"}]
    end
    ```
 


### PR DESCRIPTION
The installation section:

Add :ueberauth_spotify to your list of dependencies in mix.exs:

def deps do
  [{:ueberauth_spotify, git: "https://github.com/sondr3/ueberauth-spotify", tag: "v0.1.0"}]
end

"https://github.com/sondr3/ueberauth-spotify" does not exist.
"https://github.com/sondr3/ueberauth_spotify" with the underscore in the URL path should be listed.

def deps do
  [{:ueberauth_spotify, git: "https://github.com/sondr3/ueberauth_spotify", tag: "v0.1.0"}]
end